### PR TITLE
크롤링 api 도메인 로직 결과 처리를 Application level에서 처리하도록 수정

### DIFF
--- a/src/main/java/com/hyundai/crawldemo/application/impl/HtmlAlphanumericServiceImpl.java
+++ b/src/main/java/com/hyundai/crawldemo/application/impl/HtmlAlphanumericServiceImpl.java
@@ -1,0 +1,34 @@
+package com.hyundai.crawldemo.application.impl;
+
+import com.hyundai.crawldemo.application.port.HtmlAlphanumericService;
+import com.hyundai.crawldemo.domain.alphanumeric.model.Alphanumeric;
+import com.hyundai.crawldemo.domain.alphanumeric.port.AlphanumericService;
+import com.hyundai.crawldemo.application.cache.port.CacheService;
+import com.hyundai.crawldemo.domain.crawl.model.CrawlResult;
+import com.hyundai.crawldemo.domain.crawl.port.CrawlService;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class HtmlAlphanumericServiceImpl implements HtmlAlphanumericService {
+
+  private final AlphanumericService alphanumericService;
+  private final CrawlService crawlService;
+
+  @Override
+  public Alphanumeric getAlphanumericFromUris(List<URI> uris) {
+    List<CrawlResult> crawlResults = crawlService.crawlByUris(uris);
+
+    List<Alphanumeric> alphanumerics = crawlResults.stream()
+        .map(alphanumericService::parse)
+        .toList();
+
+    return Alphanumeric.merge(alphanumerics);
+  }
+}

--- a/src/main/java/com/hyundai/crawldemo/application/port/HtmlAlphanumericService.java
+++ b/src/main/java/com/hyundai/crawldemo/application/port/HtmlAlphanumericService.java
@@ -1,0 +1,9 @@
+package com.hyundai.crawldemo.application.port;
+
+import com.hyundai.crawldemo.domain.alphanumeric.model.Alphanumeric;
+import java.net.URI;
+import java.util.List;
+
+public interface HtmlAlphanumericService {
+  Alphanumeric getAlphanumericFromUris(List<URI> uris);
+}

--- a/src/main/java/com/hyundai/crawldemo/domain/alphanumeric/impl/AlphanumericServiceImpl.java
+++ b/src/main/java/com/hyundai/crawldemo/domain/alphanumeric/impl/AlphanumericServiceImpl.java
@@ -1,33 +1,28 @@
 package com.hyundai.crawldemo.domain.alphanumeric.impl;
 
-import static com.hyundai.crawldemo.domain.util.StringUtil.EMPTY_STRING;
-
 import com.hyundai.crawldemo.domain.alphanumeric.model.Alphanumeric;
 import com.hyundai.crawldemo.domain.alphanumeric.port.AlphanumericService;
+import com.hyundai.crawldemo.domain.crawl.model.CrawlResult;
 import com.hyundai.crawldemo.domain.util.StringUtil;
-import java.util.List;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class AlphanumericServiceImpl implements AlphanumericService {
 
   /**
    * 중복 제거된 알파벳과 숫자 목록 객체 파싱
    *
-   * @param inputs input
+   * @param crawlResult 크롤링 결과
    * @return 대문자, 소문자, 숫자 객체
    */
   @Override
-  public Alphanumeric parse(List<String> inputs) {
-    String joinedInput = String.join(EMPTY_STRING, inputs);
-    String notDuplicatedInput = StringUtil.removeDuplicate(joinedInput);
-    String alphanumericInput = StringUtil.extractAlphanumeric(notDuplicatedInput);
+  public Alphanumeric parse(CrawlResult crawlResult) {
+    String alphanumericInput = StringUtil.extractAlphanumeric(crawlResult.getHtml());
 
-    Alphanumeric alphanumeric = Alphanumeric.createByString(alphanumericInput);
-    alphanumeric.sort();
-
-    return alphanumeric;
+    return Alphanumeric.createByString(alphanumericInput);
   }
 }

--- a/src/main/java/com/hyundai/crawldemo/domain/alphanumeric/model/Alphanumeric.java
+++ b/src/main/java/com/hyundai/crawldemo/domain/alphanumeric/model/Alphanumeric.java
@@ -22,13 +22,17 @@ public class Alphanumeric {
    * @return Alphanumeric
    */
   public static Alphanumeric createByString(String input) {
-    List<Character> upperCases = new ArrayList<>();
-    List<Character> lowerCases = new ArrayList<>();
-    List<Character> numbers = new ArrayList<>();
-
     if (!StringUtils.hasText(input)) {
-      return new Alphanumeric(upperCases, lowerCases, numbers);
+      return new Alphanumeric(
+          Collections.emptyList(),
+          Collections.emptyList(),
+          Collections.emptyList()
+      );
     }
+
+    Set<Character> upperCases = new HashSet<>();
+    Set<Character> lowerCases = new HashSet<>();
+    Set<Character> numbers = new HashSet<>();
 
     char[] chars = input.toCharArray();
     for (char character : chars) {
@@ -45,7 +49,12 @@ public class Alphanumeric {
       }
     }
 
-    return new Alphanumeric(upperCases, lowerCases, numbers);
+    // TODO: 2023/01/11 sorted 효율 수정
+    return new Alphanumeric(
+        upperCases.stream().sorted().toList(),
+        lowerCases.stream().sorted().toList(),
+        numbers.stream().sorted().toList()
+    );
   }
 
   /**

--- a/src/main/java/com/hyundai/crawldemo/domain/alphanumeric/model/Alphanumeric.java
+++ b/src/main/java/com/hyundai/crawldemo/domain/alphanumeric/model/Alphanumeric.java
@@ -1,8 +1,9 @@
 package com.hyundai.crawldemo.domain.alphanumeric.model;
 
-import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.util.StringUtils;
@@ -58,12 +59,27 @@ public class Alphanumeric {
   }
 
   /**
-   * 각 목록 정렬
+   * 서로 다른 알파벳 숫자 객체 병합
+   *
+   * @param alphanumerics 알파벳 숫자 객체 목록
+   * @return 병합된 알파벳 숫자 객체
    */
-  public void sort() {
-    Collections.sort(this.upperCases);
-    Collections.sort(this.lowerCases);
-    Collections.sort(this.numbers);
+  public static Alphanumeric merge(List<Alphanumeric> alphanumerics) {
+    Set<Character> upperCases = new HashSet<>();
+    Set<Character> lowerCases = new HashSet<>();
+    Set<Character> numbers = new HashSet<>();
+    alphanumerics.forEach(alphanumeric -> {
+      upperCases.addAll(new HashSet<>(alphanumeric.getUpperCases()));
+      lowerCases.addAll(new HashSet<>(alphanumeric.getLowerCases()));
+      numbers.addAll(new HashSet<>(alphanumeric.getNumbers()));
+    });
+
+    // TODO: 2023/01/11 sorted 효율 수정
+    return new Alphanumeric(
+        upperCases.stream().sorted().toList(),
+        lowerCases.stream().sorted().toList(),
+        numbers.stream().sorted().toList()
+    );
   }
 
   /**
@@ -71,7 +87,7 @@ public class Alphanumeric {
    *
    * @return 병합된 문자열
    */
-  public String merge() {
+  public String mergeToString() {
     StringBuilder builder = new StringBuilder();
     int maxLength = Math.max(this.lowerCases.size(), this.upperCases.size());
     maxLength = Math.max(maxLength, this.numbers.size());

--- a/src/main/java/com/hyundai/crawldemo/domain/alphanumeric/model/Alphanumeric.java
+++ b/src/main/java/com/hyundai/crawldemo/domain/alphanumeric/model/Alphanumeric.java
@@ -4,12 +4,13 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.util.StringUtils;
 
 @Getter
-@RequiredArgsConstructor
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class Alphanumeric {
 
   private final List<Character> upperCases;
@@ -74,7 +75,7 @@ public class Alphanumeric {
       numbers.addAll(new HashSet<>(alphanumeric.getNumbers()));
     });
 
-    // TODO: 2023/01/11 sorted 효율 수정
+    // TODO: 2023/01/11 sorted 효율 수정(출력 할때 정렬)
     return new Alphanumeric(
         upperCases.stream().sorted().toList(),
         lowerCases.stream().sorted().toList(),

--- a/src/main/java/com/hyundai/crawldemo/domain/alphanumeric/port/AlphanumericService.java
+++ b/src/main/java/com/hyundai/crawldemo/domain/alphanumeric/port/AlphanumericService.java
@@ -1,17 +1,15 @@
 package com.hyundai.crawldemo.domain.alphanumeric.port;
 
 import com.hyundai.crawldemo.domain.alphanumeric.model.Alphanumeric;
-import java.util.List;
+import com.hyundai.crawldemo.domain.crawl.model.CrawlResult;
 
 public interface AlphanumericService {
 
   /**
    * 중복 제거된 알파벳과 숫자 목록 객체 파싱
    *
-   * @param inputs input
+   * @param crawlResult 크롤링 결과
    * @return 대문자, 소문자, 숫자 객체
    */
-
-  Alphanumeric parse(List<String> inputs);
-
+  Alphanumeric parse(CrawlResult crawlResult);
 }

--- a/src/main/java/com/hyundai/crawldemo/domain/crawl/impl/CrawlServiceImpl.java
+++ b/src/main/java/com/hyundai/crawldemo/domain/crawl/impl/CrawlServiceImpl.java
@@ -2,11 +2,13 @@ package com.hyundai.crawldemo.domain.crawl.impl;
 
 import com.hyundai.crawldemo.domain.crawl.exception.CrawlFailException;
 import com.hyundai.crawldemo.domain.crawl.exception.InvalidUrlException;
+import com.hyundai.crawldemo.domain.crawl.model.CrawlResult;
 import com.hyundai.crawldemo.domain.crawl.port.CrawlService;
 import java.io.IOException;
 import java.net.URI;
 import java.net.UnknownHostException;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -15,6 +17,7 @@ import org.springframework.util.StringUtils;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class CrawlServiceImpl implements CrawlService {
 
   private static final String DEFAULT_SCHEME = "https://";
@@ -26,12 +29,11 @@ public class CrawlServiceImpl implements CrawlService {
    * @return html string
    */
   @Override
-  public String crawl(URI uri) {
+  public CrawlResult crawl(URI uri) {
     String url = StringUtils.hasText(uri.getScheme()) ? uri.toString() : DEFAULT_SCHEME + uri;
-
     try {
       Document document = Jsoup.connect(url).get();
-      return document.toString();
+      return new CrawlResult(url, document.toString());
     } catch (UnknownHostException e) {
       throw new InvalidUrlException(url);
     } catch (IOException e) {
@@ -46,7 +48,7 @@ public class CrawlServiceImpl implements CrawlService {
    * @return html string
    */
   @Override
-  public List<String> crawlByUris(List<URI> uris) {
+  public List<CrawlResult> crawlByUris(List<URI> uris) {
     return uris.parallelStream()
         .map(this::crawl)
         .toList();

--- a/src/main/java/com/hyundai/crawldemo/domain/crawl/model/CrawlResult.java
+++ b/src/main/java/com/hyundai/crawldemo/domain/crawl/model/CrawlResult.java
@@ -1,0 +1,11 @@
+package com.hyundai.crawldemo.domain.crawl.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CrawlResult {
+  private final String url;
+  private final String html;
+}

--- a/src/main/java/com/hyundai/crawldemo/domain/crawl/port/CrawlService.java
+++ b/src/main/java/com/hyundai/crawldemo/domain/crawl/port/CrawlService.java
@@ -1,5 +1,6 @@
 package com.hyundai.crawldemo.domain.crawl.port;
 
+import com.hyundai.crawldemo.domain.crawl.model.CrawlResult;
 import java.net.URI;
 import java.util.List;
 
@@ -11,7 +12,7 @@ public interface CrawlService {
    * @param url crawling 할 url
    * @return html string
    */
-  String crawl(URI url);
+  CrawlResult crawl(URI url);
 
   /**
    * url 에 해당하는 html 정보 crawling(병렬)
@@ -19,6 +20,6 @@ public interface CrawlService {
    * @param urls crawling 할 url 목록
    * @return html 목록
    */
-  List<String> crawlByUris(List<URI> urls);
+  List<CrawlResult> crawlByUris(List<URI> urls);
 
 }

--- a/src/main/java/com/hyundai/crawldemo/domain/util/StringUtil.java
+++ b/src/main/java/com/hyundai/crawldemo/domain/util/StringUtil.java
@@ -20,26 +20,4 @@ public class StringUtil {
     }
     return input.replaceAll(ALPHANUMERIC_REGEX, EMPTY_STRING);
   }
-
-  /**
-   * 중복 문자 제거
-   *
-   * @param input 문자열
-   * @return 중복 제거된 문자열
-   */
-  public static String removeDuplicate(String input) {
-    if (!StringUtils.hasText(input)) {
-      return input;
-    }
-    StringBuilder builder = new StringBuilder();
-    for (int i = 0; i < input.length(); i++) {
-      char character = input.charAt(i);
-      boolean notContainCharacter = builder.toString().indexOf(character) < 0;
-      if (notContainCharacter) {
-        builder.append(character);
-      }
-    }
-
-    return builder.toString();
-  }
 }

--- a/src/main/java/com/hyundai/crawldemo/presentation/CrawlController.java
+++ b/src/main/java/com/hyundai/crawldemo/presentation/CrawlController.java
@@ -1,16 +1,13 @@
 package com.hyundai.crawldemo.presentation;
 
+import com.hyundai.crawldemo.application.port.HtmlAlphanumericService;
 import com.hyundai.crawldemo.domain.alphanumeric.model.Alphanumeric;
-import com.hyundai.crawldemo.domain.alphanumeric.port.AlphanumericService;
 import com.hyundai.crawldemo.domain.crawl.constant.CrawlConstant;
-import com.hyundai.crawldemo.domain.crawl.port.CrawlService;
 import com.hyundai.crawldemo.presentation.dto.CommonResponse;
 import java.net.URI;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.util.CollectionUtils;
-import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -21,11 +18,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/crawl")
 public class CrawlController {
 
-  private final CrawlService crawlService;
-  private final AlphanumericService alphanumericService;
+  private final HtmlAlphanumericService htmlAlphanumericService;
 
   /**
    * 웹사이트 크롤링 api
+   *
    * @param urls 크롤링할 url 목록
    * @return 크롤링하여 파싱한 정보 response
    */
@@ -35,13 +32,7 @@ public class CrawlController {
       urls = CrawlConstant.CRAWL_URLS;
     }
     List<URI> uris = urls.stream().map(URI::create).toList();
-
-    List<String> htmlList = crawlService.crawlByUris(uris);
-    Alphanumeric alphanumeric = alphanumericService.parse(htmlList);
-    if (alphanumeric == null || !StringUtils.hasText(alphanumeric.merge())) {
-      return CommonResponse.fail(HttpStatus.NOT_FOUND.value());
-    }
-
-    return CommonResponse.success(alphanumeric.merge());
+    Alphanumeric alphanumeric = htmlAlphanumericService.getAlphanumericFromUris(uris);
+    return CommonResponse.success(alphanumeric.mergeToString());
   }
 }

--- a/src/test/java/com/hyundai/crawldemo/application/impl/HtmlAlphanumericServiceImplTest.java
+++ b/src/test/java/com/hyundai/crawldemo/application/impl/HtmlAlphanumericServiceImplTest.java
@@ -1,0 +1,84 @@
+package com.hyundai.crawldemo.application.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.hyundai.crawldemo.domain.alphanumeric.model.Alphanumeric;
+import com.hyundai.crawldemo.domain.alphanumeric.port.AlphanumericService;
+import com.hyundai.crawldemo.domain.crawl.model.CrawlResult;
+import com.hyundai.crawldemo.domain.crawl.port.CrawlService;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class HtmlAlphanumericServiceImplTest {
+
+  @InjectMocks
+  private HtmlAlphanumericServiceImpl htmlAlphanumericService;
+
+  @Mock
+  private CrawlService crawlService;
+
+  @Mock
+  private AlphanumericService alphanumericService;
+
+  @Test
+  @DisplayName("uri 목록에 해당하는 html alphanumeric 정보 추출 test")
+  public void getAlphanumericFromUrisTest() throws Exception {
+    // given
+    List<Character> expectedUpperCases = List.of('C', 'H', 'K');
+    List<Character> expectedLowerCases = List.of('a', 'b', 'c', 'd', 'h', 'i', 'k', 'l', 'm', 'n',
+        'o', 'r', 's', 't', 'u', 'y');
+    List<Character> expectedNumbers = List.of('7', '8', '9');
+
+    URI uri1 = URI.create("https://www.kia.com");
+    URI uri2 = URI.create("https://www.hyundai.com");
+    List<URI> uris = List.of(uri1, uri2);
+    CrawlResult crawlResult1 = new CrawlResult(uri1.toString(), "<html>Kia car k9 k8 k7</html>");
+    CrawlResult crawlResult2 = new CrawlResult(
+        uri2.toString(),
+        "<html>Hyundai Car sonata hybrid</html>"
+    );
+
+    Alphanumeric alphanumeric1 = Alphanumeric.createByString(crawlResult1.getHtml());
+    Alphanumeric alphanumeric2 = Alphanumeric.createByString(crawlResult2.getHtml());
+
+    when(crawlService.crawlByUris(uris)).thenReturn(List.of(crawlResult1, crawlResult2));
+    when(alphanumericService.parse(crawlResult1)).thenReturn(alphanumeric1);
+    when(alphanumericService.parse(crawlResult2)).thenReturn(alphanumeric2);
+
+    // when
+    Alphanumeric alphanumeric = htmlAlphanumericService.getAlphanumericFromUris(uris);
+
+    // then
+    assertThat(alphanumeric).isNotNull();
+    assertThat(alphanumeric.getUpperCases()).isEqualTo(expectedUpperCases);
+    assertThat(alphanumeric.getLowerCases()).isEqualTo(expectedLowerCases);
+    assertThat(alphanumeric.getNumbers()).isEqualTo(expectedNumbers);
+  }
+
+  @Test
+  @DisplayName("uri 목록에 해당하는 html alphanumeric 정보 추출 test - empty uri")
+  public void getAlphanumericFromUrisTest_emptyUris() throws Exception {
+    // given
+    List<URI> uris = Collections.emptyList();
+
+    when(crawlService.crawlByUris(uris)).thenReturn(Collections.emptyList());
+
+    // when
+    Alphanumeric alphanumeric = htmlAlphanumericService.getAlphanumericFromUris(uris);
+
+    // then
+    assertThat(alphanumeric).isNotNull();
+    assertThat(alphanumeric.getUpperCases()).isEmpty();
+    assertThat(alphanumeric.getLowerCases()).isEmpty();
+    assertThat(alphanumeric.getNumbers()).isEmpty();
+  }
+}

--- a/src/test/java/com/hyundai/crawldemo/domain/alphanumeric/impl/AlphanumericServiceImplTest.java
+++ b/src/test/java/com/hyundai/crawldemo/domain/alphanumeric/impl/AlphanumericServiceImplTest.java
@@ -3,6 +3,7 @@ package com.hyundai.crawldemo.domain.alphanumeric.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hyundai.crawldemo.domain.alphanumeric.model.Alphanumeric;
+import com.hyundai.crawldemo.domain.crawl.model.CrawlResult;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,16 +18,17 @@ class AlphanumericServiceImplTest {
   private AlphanumericServiceImpl alphanumericService;
 
   @Test
-  @DisplayName("알파벳, 숫자 문자열 파싱 test - 중복제거, 정렬")
+  @DisplayName("알파벳, 숫자 문자열 파싱 test - 중복제거, 알파벳 추출")
   public void parseTest() throws Exception {
     // given
-    List<String> inputs = List.of("Bf3gfWEa6688", "gie51f503QFVDDR", "gjaodpq123");
-    List<Character> expectedUpperCases = List.of('B', 'D', 'E', 'F', 'Q', 'R', 'V', 'W');
-    List<Character> expectedLowerCases = List.of('a', 'd', 'e', 'f', 'g', 'i', 'j', 'o', 'p', 'q');
-    List<Character> expectedNumbers = List.of('0', '1', '2', '3', '5', '6', '8');
+    String html = "<html>Bf3&&gfWEa668>>>!@#!@#>>>8</html>";
+    CrawlResult crawlResult = new CrawlResult("www.test.com", html);
+    List<Character> expectedUpperCases = List.of('B', 'E', 'W');
+    List<Character> expectedLowerCases = List.of('a', 'f', 'g', 'h', 'l', 'm', 't');
+    List<Character> expectedNumbers = List.of('3', '6', '8');
 
     // when
-    Alphanumeric alphanumeric = alphanumericService.parse(inputs);
+    Alphanumeric alphanumeric = alphanumericService.parse(crawlResult);
 
     // then
     assertThat(alphanumeric).isNotNull();

--- a/src/test/java/com/hyundai/crawldemo/domain/alphanumeric/model/AlphanumericTest.java
+++ b/src/test/java/com/hyundai/crawldemo/domain/alphanumeric/model/AlphanumericTest.java
@@ -44,17 +44,18 @@ class AlphanumericTest {
   }
 
   @Test
-  @DisplayName("정렬 test")
-  public void sortTest() throws Exception {
+  @DisplayName("병합 test")
+  public void mergeTest() throws Exception {
     // given
-    String input = "dEaG28A5Fk1";
-    List<Character> expectedLowerCases = List.of('a', 'd', 'k');
-    List<Character> expectedUpperCases = List.of('A', 'E', 'F', 'G');
-    List<Character> expectedNumbers = List.of('1', '2', '5', '8');
-    Alphanumeric alphanumeric = Alphanumeric.createByString(input);
+    Alphanumeric alphanumeric1 = Alphanumeric.createByString("aAdE125FGk8");
+    Alphanumeric alphanumeric2 = Alphanumeric.createByString("fEThNV5FGgeoi120");
+    List<Character> expectedUpperCases = List.of('A', 'E', 'F', 'G', 'N', 'T', 'V');
+    List<Character> expectedLowerCases = List.of('a', 'd', 'e', 'f', 'g', 'h', 'i', 'k', 'o');
+    List<Character> expectedNumbers = List.of('0', '1', '2', '5', '8');
+
 
     // when
-    alphanumeric.sort();
+    Alphanumeric alphanumeric = Alphanumeric.merge(List.of(alphanumeric1, alphanumeric2));
 
     // then
     assertThat(alphanumeric).isNotNull();
@@ -63,33 +64,32 @@ class AlphanumericTest {
     assertThat(alphanumeric.getNumbers()).isEqualTo(expectedNumbers);
   }
 
+
   @Test
-  @DisplayName("병합 Test")
-  public void mergeTest() throws Exception {
+  @DisplayName("문자열 병합 Test")
+  public void mergeToStringTest() throws Exception {
     // given
     String input = "dEaG28A5Fk1Q";
     String expected = "Aa1Ed2Fk5G8Q";
     Alphanumeric alphanumeric = Alphanumeric.createByString(input);
-    alphanumeric.sort();
 
     // when
-    String merge = alphanumeric.merge();
+    String merge = alphanumeric.mergeToString();
 
     // then
     assertThat(merge).isEqualTo(expected);
   }
 
   @Test
-  @DisplayName("병합 Test - 빈 객체")
-  public void mergeTest_emptyString() throws Exception {
+  @DisplayName("문자열 병합 Test - 빈 객체")
+  public void mergeToStringTest_emptyString() throws Exception {
     // given
     String input = null;
     String expected = "";
     Alphanumeric alphanumeric = Alphanumeric.createByString(input);
-    alphanumeric.sort();
 
     // when
-    String merge = alphanumeric.merge();
+    String merge = alphanumeric.mergeToString();
 
     // then
     assertThat(merge).isEqualTo(expected);

--- a/src/test/java/com/hyundai/crawldemo/domain/crawl/impl/CrawlServiceImplTest.java
+++ b/src/test/java/com/hyundai/crawldemo/domain/crawl/impl/CrawlServiceImplTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.hyundai.crawldemo.domain.crawl.constant.CrawlConstant;
 import com.hyundai.crawldemo.domain.crawl.exception.InvalidUrlException;
+import com.hyundai.crawldemo.domain.crawl.model.CrawlResult;
 import com.hyundai.crawldemo.domain.crawl.port.CrawlService;
 import java.net.URI;
 import java.util.List;
@@ -27,10 +28,12 @@ class CrawlServiceImplTest {
     URI uri = URI.create(url);
 
     // when
-    String html = crawlService.crawl(uri);
+    CrawlResult result = crawlService.crawl(uri);
 
     // then
-    assertThat(html).isNotBlank();
+    assertThat(result).isNotNull();
+    assertThat(result.getUrl()).isEqualTo(url);
+    assertThat(result.getHtml()).isNotBlank();
   }
 
   @Test
@@ -52,10 +55,12 @@ class CrawlServiceImplTest {
     URI uri = URI.create(url);
 
     // when
-    String html = crawlService.crawl(uri);
+    CrawlResult result = crawlService.crawl(uri);
 
     // then
-    assertThat(html).isNotBlank();
+    assertThat(result).isNotNull();
+    assertThat(result.getUrl()).isEqualTo("https://" + url);
+    assertThat(result.getHtml()).isNotBlank();
   }
 
   @Test
@@ -66,11 +71,16 @@ class CrawlServiceImplTest {
     List<URI> uris = crawlUrls.stream().map(URI::create).toList();
 
     // when
-    List<String> htmlList = crawlService.crawlByUris(uris);
+    List<CrawlResult> results = crawlService.crawlByUris(uris);
 
     // then
-    assertThat(crawlUrls.size()).isEqualTo(htmlList.size());
-    htmlList.forEach(html -> assertThat(html).isNotBlank());
+    assertThat(results).isNotEmpty();
+    assertThat(crawlUrls.size()).isEqualTo(results.size());
+    results.forEach(result -> {
+      assertThat(result).isNotNull();
+      assertThat(result.getUrl()).isIn(crawlUrls);
+      assertThat(result.getHtml()).isNotBlank();
+    });
   }
 
   @Test

--- a/src/test/java/com/hyundai/crawldemo/domain/crawl/util/StringUtilTest.java
+++ b/src/test/java/com/hyundai/crawldemo/domain/crawl/util/StringUtilTest.java
@@ -34,31 +34,4 @@ class StringUtilTest {
     // then
     assertThat(extracted).isEqualTo(input);
   }
-
-  @Test
-  @DisplayName("문자열 중복 제거 test")
-  public void removeDuplicateTest() throws Exception {
-    // given
-    String input = "cc051123aaf22f44ff11eeegg";
-    String expected = "c05123af4eg";
-
-    // when
-    String result = StringUtil.removeDuplicate(input);
-
-    // then
-    assertThat(result).isEqualTo(expected);
-  }
-
-  @Test
-  @DisplayName("문자열 중복 제거 test - null")
-  public void removeDuplicateTest_null() throws Exception {
-    // given
-    String input = null;
-
-    // when
-    String result = StringUtil.removeDuplicate(input);
-
-    // then
-    assertThat(result).isEqualTo(null);
-  }
 }


### PR DESCRIPTION
### as-is
크롤링 결과값을 알파벳, 숫자 추출하던 작업 순서를 controller에서 일일이 처리
### to-be
* application level 로직으로 변경